### PR TITLE
Upload to codecov with a token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       - run: hatch run test:cov
       - uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
   build:


### PR DESCRIPTION
Tokenless upload is flaky